### PR TITLE
Update CI to use automatic envtest discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,8 @@ jobs:
         go-version: '1.25'
         cache: true
 
-    - name: Setup envtest binaries
-      run: make setup-envtest
-
     - name: Run tests
-      run: |
-        source ./test/envtest/env.sh
-        make test
+      run: make test
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v9.0.0


### PR DESCRIPTION
Fixes #11

CI workflow was still using manual env.sh sourcing which is no longer needed. Tests now automatically discover envtest binaries via make test target.