### PR TITLE
Update package imports to kubernetes-mcp-server

### DIFF
--- a/pkg/generator/templates/handlers.go.tmpl
+++ b/pkg/generator/templates/handlers.go.tmpl
@@ -5,8 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/modelcontextprotocol/go-sdk/api"
-	internalk8s "github.com/friedrichwilken/extendable-kubernetes-mcp-server/internal/k8s"
+	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/generator/templates/toolset.go.tmpl
+++ b/pkg/generator/templates/toolset.go.tmpl
@@ -1,8 +1,8 @@
 package {{.Package}}
 
 import (
-	"github.com/modelcontextprotocol/go-sdk/api"
-	internalk8s "github.com/friedrichwilken/extendable-kubernetes-mcp-server/internal/k8s"
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 )
 
 // {{.CRD.Kind}}Toolset provides MCP tools for managing {{.CRD.Kind}} custom resources

--- a/test/e2e/toolgen_ek8sms_test.go
+++ b/test/e2e/toolgen_ek8sms_test.go
@@ -99,9 +99,9 @@ func findEK8SMSDirectory(t *testing.T) string {
 	// Try to find ek8sms relative to current location
 	// Assuming mcp-toolgen and ek8sms are sibling directories
 	possiblePaths := []string{
-		"../../../extendable-kubernetes-mcp-server",        // local dev: from test/e2e/ up to workspace
-		"../../extendable-kubernetes-mcp-server",           // local dev: from test/ up to workspace
-		"../extendable-kubernetes-mcp-server",              // CI: sibling in workspace
+		"../../../extendable-kubernetes-mcp-server",                                             // local dev: from test/e2e/ up to workspace
+		"../../extendable-kubernetes-mcp-server",                                                // local dev: from test/ up to workspace
+		"../extendable-kubernetes-mcp-server",                                                   // CI: sibling in workspace
 		filepath.Join(os.Getenv("HOME"), "claude-playroom", "extendable-kubernetes-mcp-server"), // local dev: absolute
 	}
 


### PR DESCRIPTION
## What

Updates template imports to use kubernetes-mcp-server packages instead of custom paths.

## Changes

- `toolset.go.tmpl`: Use `github.com/containers/kubernetes-mcp-server/pkg/api` and `pkg/kubernetes`
- `handlers.go.tmpl`: Use `github.com/containers/kubernetes-mcp-server/pkg/kubernetes`
- Remove references to modelcontextprotocol/go-sdk/api and custom internal paths

## Why

Generated toolsets need to integrate with kubernetes-mcp-server architecture. This is the first step toward full compatibility.

## Testing

- All tests pass including E2E test
- Pre-commit hooks (format, lint, test) pass

## Part of

Issue #15 - PR 1/6