### PR TITLE
PR 2: Add Tool struct generation

### DIFF
--- a/pkg/generator/templates/toolset.go.tmpl
+++ b/pkg/generator/templates/toolset.go.tmpl
@@ -31,9 +31,11 @@ func (t *{{.CRD.Kind}}Toolset) GetTools(o internalk8s.Openshift) []api.ServerToo
 // {{generateMethodName $operation $.CRD.Plural | ToLower}}Tool creates the MCP tool for {{$operation}} operations
 func {{generateMethodName $operation $.CRD.Plural | ToLower}}Tool() api.ServerTool {
 	return api.ServerTool{
-		Name:        "{{generateToolName $operation $.CRD.Plural}}",
-		Description: "{{$operation | ToTitle}} a {{$.CRD.Kind}} custom resource",
-		InputSchema: {{$operation}}{{$.CRD.Kind}}Schema(),
+		Tool: api.Tool{
+			Name:        "{{generateToolName $operation $.CRD.Plural}}",
+			Description: "{{$operation | ToTitle}} a {{$.CRD.Kind}} custom resource",
+			InputSchema: {{$operation}}{{$.CRD.Kind}}Schema(),
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary
This PR modifies the toolset template to generate proper `api.Tool` structs nested within `api.ServerTool`, following the k8sms API structure.

## Changes
- Updated `toolset.go.tmpl` to nest `Tool` struct within `ServerTool`
- Added `Name`, `Description`, and `InputSchema` fields to `Tool` struct
- Maintains backward compatibility for incremental migration

## Part of Issue
Resolves part of #15

## Dependencies
- Depends on: PR #16 (merged)
- Required for: PR 3 (ServerTool structure)

## Testing
- All unit tests pass
- E2E test passes
- Pre-commit hooks pass

## Notes
- `Handler` will be added in PR 5
- `ClusterAware` and `TargetListProvider` will be added in PR 3
- This is step 2 of 6 in the template refactoring plan