### PR TITLE
PR 3: Update ServerTool structure

### DIFF
--- a/pkg/generator/templates/toolset.go.tmpl
+++ b/pkg/generator/templates/toolset.go.tmpl
@@ -36,6 +36,7 @@ func {{generateMethodName $operation $.CRD.Plural | ToLower}}Tool() api.ServerTo
 			Description: "{{$operation | ToTitle}} a {{$.CRD.Kind}} custom resource",
 			InputSchema: {{$operation}}{{$.CRD.Kind}}Schema(),
 		},
+		Handler: Handle{{$operation | ToTitle}}{{$.CRD.Kind}},
 	}
 }
 


### PR DESCRIPTION
## Summary
This PR adds the Handler field to ServerTool in the toolset template, completing the ServerTool structure alignment with k8sms API.

## Changes
- Added `Handler` field to `ServerTool` referencing handler functions
- Handler functions are generated in handlers.go.tmpl (e.g., `HandleCreateFunction`)
- `ClusterAware` and `TargetListProvider` remain nil for now (default behavior)

## Part of Issue
Resolves part of #15

## Dependencies
- Depends on: PR #17 (merged)
- Required for: PR 4 (schema conversion)

## Testing
- All unit tests pass
- E2E test passes
- Pre-commit hooks pass

## Notes
- This PR focuses only on adding the Handler field
- ClusterAware/TargetListProvider could be added later if needed for specific tools
- Handler functions are referenced but actual implementation happens in handlers.go.tmpl
- This is step 3 of 6 in the template refactoring plan