### PR TITLE
PR 6: Add toolset registration

### DIFF
--- a/pkg/generator/templates/toolset.go.tmpl
+++ b/pkg/generator/templates/toolset.go.tmpl
@@ -3,10 +3,14 @@ package {{.Package}}
 import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 )
 
 // {{.CRD.Kind}}Toolset provides MCP tools for managing {{.CRD.Kind}} custom resources
 type {{.CRD.Kind}}Toolset struct{}
+
+// Ensure {{.CRD.Kind}}Toolset implements api.Toolset interface
+var _ api.Toolset = (*{{.CRD.Kind}}Toolset)(nil)
 
 // GetName returns the name of this toolset
 func (t *{{.CRD.Kind}}Toolset) GetName() string {
@@ -42,8 +46,7 @@ func {{generateMethodName $operation $.CRD.Plural | ToLower}}Tool() api.ServerTo
 
 {{end}}
 
-// init registers this toolset
+// init registers this toolset with the global registry
 func init() {
-	// This will be called when the package is imported
-	// The actual registration happens in the main server
+	toolsets.Register(&{{.CRD.Kind}}Toolset{})
 }


### PR DESCRIPTION
## Summary
This final PR adds automatic toolset registration with the global registry, completing the k8sms compatibility work.

## Changes
- **Import added**: `github.com/containers/kubernetes-mcp-server/pkg/toolsets`
- **Interface compliance check**: `var _ api.Toolset = (*Toolset)(nil)` ensures compile-time interface validation
- **init() function**: Calls `toolsets.Register(&Toolset{})` for automatic registration when package is imported
- **Auto-discovery**: Generated toolsets are now automatically discovered by ek8sms

## Part of Issue
Closes #15

## Dependencies
- Depends on: PR #20 (merged)
- **Final PR**: Completes all 6 PRs in the refactoring plan

## Testing
- ✅ All unit tests pass
- ✅ E2E test passes (generated code compiles with ek8sms)
- ✅ Pre-commit hooks pass
- ✅ Generated toolsets auto-register and work with ek8sms

## Notes
- This is the final PR (step 6 of 6) in the template refactoring plan
- Generated toolsets now fully compatible with k8sms API
- No manual registration needed - import triggers auto-registration
- Generated code can now be used directly without modifications

## 🎉 Template Refactoring Complete!
All generated toolsets are now fully compatible with kubernetes-mcp-server architecture.