### PR TITLE
Fix nested type generation in types.go template

### DIFF
--- a/pkg/generator/helpers.go
+++ b/pkg/generator/helpers.go
@@ -335,6 +335,25 @@ func wrapComment(text string, maxWidth int) string {
 	return strings.Join(lines, "\n")
 }
 
+// escapeString escapes a string for use in Go string literals
+// It handles newlines, quotes, and other special characters
+func escapeString(s string) string {
+	// Replace backslashes first to avoid double-escaping
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	// Replace quotes
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	// Replace newlines with space to keep descriptions on one line
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", "")
+	// Replace tabs with spaces
+	s = strings.ReplaceAll(s, "\t", " ")
+	// Collapse multiple spaces
+	for strings.Contains(s, "  ") {
+		s = strings.ReplaceAll(s, "  ", " ")
+	}
+	return strings.TrimSpace(s)
+}
+
 // generateFieldName generates a Go field name from a JSON field name
 func generateFieldName(jsonName string) string {
 	return toPascalCase(jsonName)

--- a/pkg/generator/templates.go
+++ b/pkg/generator/templates.go
@@ -18,6 +18,7 @@ func (g *Generator) loadEmbeddedTemplates() error {
 		"Contains":              contains,
 		"Join":                  join,
 		"Quote":                 quote,
+		"EscapeString":          escapeString,
 		"ConvertSchemaToGoCode": convertSchemaToGoCode,
 		// Add helper functions for template generation
 		"generateMethodName": generateMethodName,
@@ -52,6 +53,7 @@ func (g *Generator) createInlineTemplates() error {
 		"Contains":              contains,
 		"Join":                  join,
 		"Quote":                 quote,
+		"EscapeString":          escapeString,
 		"ConvertSchemaToGoCode": convertSchemaToGoCode,
 		"generateMethodName":    generateMethodName,
 		"generateToolName":      generateToolName,

--- a/pkg/generator/templates/schema.go.tmpl
+++ b/pkg/generator/templates/schema.go.tmpl
@@ -239,7 +239,7 @@ func {{.CRD.Kind | ToLower}}SpecSchema() *jsonschema.Schema {
 				Type:        "object",
 				{{end}}
 				{{if $field.Description}}
-				Description: "{{$field.Description}}",
+				Description: "{{EscapeString $field.Description}}",
 				{{end}}
 			},
 			{{end}}
@@ -271,7 +271,7 @@ func {{.CRD.Kind | ToLower}}StatusSchema() *jsonschema.Schema {
 				Type:        "object",
 				{{end}}
 				{{if $field.Description}}
-				Description: "{{$field.Description}}",
+				Description: "{{EscapeString $field.Description}}",
 				{{end}}
 			},
 			{{end}}

--- a/pkg/generator/templates/types.go.tmpl
+++ b/pkg/generator/templates/types.go.tmpl
@@ -29,7 +29,7 @@ type {{.CRD.Kind}} struct {
 {{end}}
 type {{.CRD.Kind}}Spec struct {
 	{{range $field := .SpecType.GetStructFields}}
-	{{$field.GetGoFieldName}} {{$field.GoType}} `{{$field.JSONTag}}`{{if $.IncludeComments}}{{if $field.Description}} // {{$field.Description}}{{end}}{{end}}
+	{{$field.GetGoFieldName}} {{$field.GoType}} `{{$field.JSONTag}}`{{if $.IncludeComments}}{{if $field.Description}} // {{EscapeString $field.Description}}{{end}}{{end}}
 	{{end}}
 }
 {{end}}
@@ -40,9 +40,49 @@ type {{.CRD.Kind}}Spec struct {
 {{end}}
 type {{.CRD.Kind}}Status struct {
 	{{range $field := .StatusType.GetStructFields}}
-	{{$field.GetGoFieldName}} {{$field.GoType}} `{{$field.JSONTag}}`{{if $.IncludeComments}}{{if $field.Description}} // {{$field.Description}}{{end}}{{end}}
+	{{$field.GetGoFieldName}} {{$field.GoType}} `{{$field.JSONTag}}`{{if $.IncludeComments}}{{if $field.Description}} // {{EscapeString $field.Description}}{{end}}{{end}}
 	{{end}}
 }
+{{end}}
+
+{{/* Generate nested types from SpecType */}}
+{{if .SpecType}}
+{{- template "nestedTypes" .SpecType -}}
+{{end}}
+
+{{/* Generate nested types from StatusType */}}
+{{if .StatusType}}
+{{- template "nestedTypes" .StatusType -}}
+{{end}}
+
+{{/* Template for recursively generating nested types */}}
+{{define "nestedTypes"}}
+{{- range $field := .GetStructFields -}}
+{{- if $field.IsComplexType}}
+
+// {{$field.Name}} represents a nested type in the schema
+type {{$field.Name}} struct {
+	{{- range $nestedField := $field.GetStructFields}}
+	{{$nestedField.GetGoFieldName}} {{$nestedField.GoType}} `{{$nestedField.JSONTag}}`{{if $nestedField.Description}} // {{EscapeString $nestedField.Description}}{{end}}
+	{{- end}}
+}
+{{/* Recursively generate nested types within this type */}}
+{{- template "nestedTypes" $field -}}
+{{- end -}}
+{{- if $field.Items -}}
+{{- if $field.Items.IsComplexType}}
+
+// {{$field.Items.Name}} represents an array item type in the schema
+type {{$field.Items.Name}} struct {
+	{{- range $nestedField := $field.Items.GetStructFields}}
+	{{$nestedField.GetGoFieldName}} {{$nestedField.GoType}} `{{$nestedField.JSONTag}}`{{if $nestedField.Description}} // {{EscapeString $nestedField.Description}}{{end}}
+	{{- end}}
+}
+{{/* Recursively generate nested types within array items */}}
+{{- template "nestedTypes" $field.Items -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 {{end}}
 
 {{if .IncludeComments}}


### PR DESCRIPTION
## Summary

Fixes the types.go.tmpl template to properly generate all nested object and array item types from CRD schemas, resolving compilation errors due to undefined type references.

## Changes

### types.go.tmpl
- Add recursive nested type generation via new `nestedTypes` template
- Handles both `Properties` (nested objects) and `Items` (array elements)
- Generates complete type definitions for all schema structures

### helpers.go
- Add `escapeString()` function
- Escapes newlines, quotes, backslashes, and tabs in descriptions
- Collapses multiple spaces
- Prevents Go syntax errors from multiline CRD descriptions

### templates.go
- Register `escapeString` in template FuncMap
- Available as `EscapeString` in all templates

### schema.go.tmpl
- Use `EscapeString` for field descriptions
- Prevents syntax errors in JSON schema descriptions

## Impact

- Generated types.go now includes all nested types (e.g., `FunctionSpecEnvItem`, `FunctionSpecResourceconfiguration`, etc.)
- Eliminates "undefined type" compilation errors
- Generated types.go files now compile successfully
- For complex CRDs like Kyma Functions, generates 25+ types instead of just 4

## Example

For a CRD with `spec.env[]item.valueFrom.configMapKeyRef`, the template now generates:
- `FunctionSpec` (top level)
- `FunctionSpecEnvItem` (array item)
- `FunctionSpecEnvItemValuefrom` (nested object)
- `FunctionSpecEnvItemValuefromConfigmapkeyref` (deeply nested)

## Testing

- ✅ All unit tests pass
- ✅ Integration tests pass
- ✅ E2E test passes
- ✅ Linter passes with no issues
- ✅ Generated code from Kyma Functions CRD compiles successfully (types.go)

## Related Issues

This addresses the root cause of undefined type references in generated code. Note that handlers.go and schema.go still have API compatibility issues that will be addressed in a separate PR.