### PR TITLE
Fix --register flag to support import blocks and conditional context …

### DIFF
--- a/pkg/generator/templates/toolset.go.tmpl
+++ b/pkg/generator/templates/toolset.go.tmpl
@@ -1,8 +1,10 @@
 package {{.Package}}
 
 import (
+	{{- if or .GenerateCRDResource .GenerateDocResource}}
 	"context"
 
+	{{- end}}
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"


### PR DESCRIPTION
…import

The --register flag was failing when modules.go used import blocks instead of single-line imports. Additionally, the context import was unconditionally added even when resources weren't generated, causing unused import errors.

Changes:
- Update registration.go to handle both import block and single-line formats
- Make context import conditional in toolset.go.tmpl (only when resources enabled)

This enables --register to work correctly with extendable-kubernetes-mcp-server's modules.go pattern.